### PR TITLE
Added tests for writing/reading a moderate amount of data split over many small files

### DIFF
--- a/_functions.R
+++ b/_functions.R
@@ -31,6 +31,11 @@ benchmark <- function(name, task) {
 aggregate_benchmark <- function(name, iterations, task) {
   dump_cache()
 
+  # perform the timer on the entire set of iterations instead of timing each
+  # iteration individually - we need to do this because the overhead of using
+  # system.time is HUGE! calling this in a loop is disastrous for performance,
+  # and thus causes very inaccurate benchmarks. as a result, each iteration
+  # should strive to minimize calls unrelated to the actual filesystem being tested
   aggregate_time = system.time({
     for (i in 1:iterations) {
       task(i)

--- a/_functions.R
+++ b/_functions.R
@@ -5,6 +5,10 @@ target <- function(...) {
 
 times <- list()
 
+# construct a static 100MB dataframe
+static_df_rows <- 0.0291268 * 100*1024*1024
+static_df <- data.frame(x1 = runif(static_df_rows), x2 = runif(static_df_rows))
+
 benchmark_begin <- function() {
   times <<- list()
 }
@@ -22,6 +26,18 @@ benchmark <- function(name, task) {
   } else {
     times[[name]] <<- task
   }
+}
+
+aggregate_benchmark <- function(name, iterations, task) {
+  dump_cache()
+
+  aggregate_time = system.time({
+    for (i in 1:iterations) {
+      task(i)
+    }
+  })
+
+  times[[name]] <<- aggregate_time
 }
 
 benchmark_end <- function() {
@@ -70,6 +86,14 @@ write_random_csv <- function(path, bytes) {
   system.time({
     data.table::fwrite(df, file = path, row.names = FALSE, col.names = FALSE)
   })
+}
+
+write_static_csv <- function(path, num_files, num_iter) {
+  num_rows <- as.integer(static_df_rows / num_files)
+  start <- (num_iter - 1) * num_rows
+  end <- start + num_rows
+  sub_df <- static_df[start:end, ]
+  data.table::fwrite(sub_df, file = path, row.names = FALSE, col.names = FALSE)
 }
 
 dump_cache <- function() {

--- a/main.R
+++ b/main.R
@@ -32,6 +32,23 @@ unlink(target("1mb.csv"))
 unlink(target("100mb.csv"))
 unlink(target("1gb.csv"))
 
+# Small files tests =========
+for (i in 1:4) {
+  num_files <- 10 ^ i
+  file_size <- 100*1024*1024 / num_files
+
+  aggregate_benchmark(sprintf("base::write.csv, 100MB over %s files", num_files), num_files, function(iter) {
+    write_static_csv(target(sprintf("small_%s.csv", iter)), num_files, iter)
+  })
+
+  aggregate_benchmark(sprintf("base::read.csv, 100MB over %s files", num_files), num_files, function(iter) {
+    data.table::fread(target(sprintf("small_%s.csv", iter)))
+  })
+
+  for (j in 1:num_files) {
+    unlink(target(sprintf("small_%s.csv", j)))
+  }
+}
 
 # Read CRAN logs =========
 


### PR DESCRIPTION
This adds read/write tests for dealing with a moderate amount of data (100MB) over many smaller files (10, 100, 1000, and 10000).

This seems to really stress the EFS latency issue, as can be seen in the following run results:

**Local SSD**
```"base::write.csv, 100MB over 10 files",0.628,0.144,0.284999999999968
"base::read.csv, 100MB over 10 files",0.248000000000005,0.0919999999999987,0.240999999999985
"base::write.csv, 100MB over 100 files",0.664000000000001,0.0640000000000001,0.73399999999998
"base::read.csv, 100MB over 100 files",0.292000000000002,0.0719999999999992,0.412000000000035
"base::write.csv, 100MB over 1000 files",0.655999999999999,0.0599999999999987,0.729999999999961
"base::read.csv, 100MB over 1000 files",0.567999999999998,0.171999999999997,0.897999999999968
"base::write.csv, 100MB over 10000 files",1.96,0.272000000000002,2.24600000000004
"base::read.csv, 100MB over 10000 files",4.204,0.936,6.29599999999999
```

**EBS**
```
"base::write.csv, 100MB over 10 files",0.756,0.1,0.861
"base::read.csv, 100MB over 10 files",0.287,0.05,1.008
"base::write.csv, 100MB over 100 files",0.942,0.117,1.059
"base::read.csv, 100MB over 100 files",0.381,0.073,0.874
"base::write.csv, 100MB over 1000 files",0.96,0.1,1.061
"base::read.csv, 100MB over 1000 files",0.792999999999999,0.161,1.624
"base::write.csv, 100MB over 10000 files",3.046,0.489,3.539
"base::read.csv, 100MB over 10000 files",5.71,0.786,10.307
```

**EFS**
```
"base::write.csv, 100MB over 10 files",0.779,0.078,2.691
"base::read.csv, 100MB over 10 files",0.278,0.042,4.447
"base::write.csv, 100MB over 100 files",0.972,0.12,5.988
"base::read.csv, 100MB over 100 files",0.382,0.099,3.551
"base::write.csv, 100MB over 1000 files",1.198,0.206,22.515
"base::read.csv, 100MB over 1000 files",0.991000000000001,0.214,8.65300000000001
"base::write.csv, 100MB over 10000 files",4.791,0.941,115.582
"base::read.csv, 100MB over 10000 files",7.055,1.507,70.718
```

From the results, we can see that the performance using EBS was fairly similar to my local disk while EFS was anywhere from 11 to 50 times slower!

Addresses https://github.com/rstudio/platform-team/issues/32