### PR TITLE
Add FST random read tests

### DIFF
--- a/main.R
+++ b/main.R
@@ -1,4 +1,5 @@
 library(data.table)
+library(fst)
 library(R.utils) # needed for fread to read .gz files
 library(vroom)
 
@@ -49,6 +50,61 @@ for (i in 1:4) {
     unlink(target(sprintf("small_%s.csv", j)))
   }
 }
+
+# FST tests ========
+# Generate a random data frame (approximately 1GB of data), save it to disk,
+# then perform random read tests of different lengths on the file
+size_100mb <- 100*1024*1024
+num_rows <- 0.0625 * size_100mb
+size_per_row <- size_100mb / num_rows
+fst_frame <- data.frame(x1 = runif(num_rows), x2 = runif(num_rows))
+write.fst(fst_frame, target("dataset.fst"))
+
+num_read <- 0
+benchmark("FST random reads, 100MB over 10*10MB reads", system.time({
+  rows_to_read <- (10*1024*1024) / size_per_row
+  while (num_read < size_100mb) {
+    from <- runif(1, 0, num_rows - rows_to_read)
+    to <- from + rows_to_read
+    fst_subset <- read.fst(target("dataset.fst"), NULL, from, to)
+    num_read <- num_read + object.size(fst_subset)
+  }
+}))
+
+num_read <- 0
+benchmark("FST random reads, 100MB over 100*1MB reads", system.time({
+  rows_to_read <- (1*1024*1024) / size_per_row
+  while (num_read < size_100mb) {
+    from <- runif(1, 0, num_rows - rows_to_read)
+    to <- from + rows_to_read
+    fst_subset <- read.fst(target("dataset.fst"), NULL, from, to)
+    num_read <- num_read + object.size(fst_subset)
+  }
+}))
+
+num_read <- 0
+benchmark("FST random reads, 100MB over 1000*100KB reads", system.time({
+  rows_to_read <- (100*1024) / size_per_row
+  while (num_read < size_100mb) {
+    from <- runif(1, 0, num_rows - rows_to_read)
+    to <- from + rows_to_read
+    fst_subset <- read.fst(target("dataset.fst"), NULL, from, to)
+    num_read <- num_read + object.size(fst_subset)
+  }
+}))
+
+num_read <- 0
+benchmark("FST random reads, 100MB over 10000*10KB reads", system.time({
+  rows_to_read <- (10*1024) / size_per_row
+  while (num_read < size_100mb) {
+    from <- runif(1, 0, num_rows - rows_to_read)
+    to <- from + rows_to_read
+    fst_subset <- read.fst(target("dataset.fst"), NULL, from, to)
+    num_read <- num_read + object.size(fst_subset)
+  }
+}))
+
+unlink(target("dataset.fst"))
 
 # Read CRAN logs =========
 

--- a/renv.lock
+++ b/renv.lock
@@ -107,6 +107,13 @@
       "Repository": "RSPM",
       "Hash": "fea074fb67fe4c25d47ad09087da847d"
     },
+    "fst": {
+      "Package": "fst",
+      "Version": "0.9.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "66c2d5dffed8d181b9555617beb2d0f9"
+    },
     "glue": {
       "Package": "glue",
       "Version": "1.4.2",


### PR DESCRIPTION
Add FST random read tests to get some random access patterns tested.

This also performs poorly on EFS, due to the same latency issue.

**Local disk**
```
  task                                           user system elapsed
  <chr>                                         <dbl>  <dbl>   <dbl>
1 FST random reads, 100MB over 10*10MB reads    1.1    0.132   0.25 
2 FST random reads, 100MB over 100*1MB reads    3.37   0.192   0.53 
3 FST random reads, 100MB over 1000*100KB reads 0.644  0.212   0.482
4 FST random reads, 100MB over 10000*10KB reads 0.912  0.440   1.60
```

**EBS**
```
  task                                           user system elapsed
  <chr>                                         <dbl>  <dbl>   <dbl>
1 FST random reads, 100MB over 10*10MB reads    0.268 0.075    0.282
2 FST random reads, 100MB over 100*1MB reads    0.479 0.0980   0.447
3 FST random reads, 100MB over 1000*100KB reads 1.09  0.150    0.934
4 FST random reads, 100MB over 10000*10KB reads 1.11  0.436    2.87
```

**EFS**
```
  task                                           user system elapsed
  <chr>                                         <dbl>  <dbl>   <dbl>
1 FST random reads, 100MB over 10*10MB reads    0.343  0.089    1.26
2 FST random reads, 100MB over 100*1MB reads    0.755  0.14     2.32
3 FST random reads, 100MB over 1000*100KB reads 3.44   0.229    7.40
4 FST random reads, 100MB over 10000*10KB reads 1.88   0.859   33.4 
```

Addresses https://github.com/rstudio/platform-team/issues/31