### PR TITLE
Added parallel tests using DD

### DIFF
--- a/main.R
+++ b/main.R
@@ -112,8 +112,8 @@ unlink(target("small-parallel_*.dat"))
 # ===============================================================================================================
 
 # FST tests =====================================================================================================
-Generate a random data frame (approximately 1GB of data), save it to disk,
-then perform random read tests of different lengths on the file
+# Generate a random data frame (approximately 1GB of data), save it to disk,
+# then perform random read tests of different lengths on the file
 size_100mb <- 100*1024*1024
 num_rows <- 0.0625 * size_100mb
 size_per_row <- size_100mb / num_rows

--- a/main.R
+++ b/main.R
@@ -1,5 +1,6 @@
 library(data.table)
 library(fst)
+library(parallel)
 library(R.utils) # needed for fread to read .gz files
 library(vroom)
 
@@ -9,15 +10,16 @@ benchmark_begin()
 
 dir.create(target("lib"), recursive = TRUE, showWarnings = FALSE)
 
+# Install common R packages =====================================================================================
 benchmark("Install MASS", time_install("MASS", lib = target("lib")))
 benchmark("Install lattice", time_install("lattice", lib = target("lib")))
 benchmark("Install BH", time_install("BH", lib = target("lib")))
 
 utils::remove.packages(c("MASS", "lattice", "BH"), lib = target("lib"))
 unlink(target("lib"), recursive = TRUE)
+# ===============================================================================================================
 
-# Write, then read, 1GB CSV =========
-
+# Write, then read, 1GB CSV =====================================================================================
 benchmark("base::write.csv, 10KB", write_random_csv(target("10kb.csv"), 10*1024))
 benchmark("base::write.csv, 1MB", write_random_csv(target("1mb.csv"), 1024*1024))
 benchmark("base::write.csv, 100MB", write_random_csv(target("100mb.csv"), 100*1024*1024))
@@ -32,8 +34,35 @@ unlink(target("10kb.csv"))
 unlink(target("1mb.csv"))
 unlink(target("100mb.csv"))
 unlink(target("1gb.csv"))
+# ===============================================================================================================
 
-# Small files tests =========
+# Parallel tests with 1GB readers/writers =======================================================================
+for (i in 1:4) {
+  num_writers <- 2^i
+  benchmark(sprintf("Parallel DD write, 1GB * %d simultaneous writers", num_writers), system.time({
+    mclapply(1:num_writers, function(id) {
+      file <- target(sprintf("parallel_%d.dat", id))
+      command <- sprintf("dd if=/dev/zero of=%s bs=1048576 count=1024 conv=sync oflag=nocache", file)
+      system(command)
+    }, mc.preschedule = FALSE, mc.cores = num_writers)
+  }))
+}
+
+for (i in 1:4) {
+  num_readers <- 2^i
+  benchmark(sprintf("Parallel DD read, 1GB * %d simultaneous readers", num_readers), system.time({
+    mclapply(1:num_readers, function(id) {
+      file <- target(sprintf("parallel_%d.dat", id))
+      command <- sprintf("dd if=%s of=/dev/null bs=1048576 count=1024 iflag=nocache", file)
+      system(command)
+    }, mc.preschedule = FALSE, mc.cores = num_readers)
+  }))
+}
+
+unlink(target("parallel_*.dat"))
+# ===============================================================================================================
+
+# Small files tests =============================================================================================
 for (i in 1:4) {
   num_files <- 10 ^ i
   file_size <- 100*1024*1024 / num_files
@@ -50,10 +79,41 @@ for (i in 1:4) {
     unlink(target(sprintf("small_%s.csv", j)))
   }
 }
+# ===============================================================================================================
 
-# FST tests ========
-# Generate a random data frame (approximately 1GB of data), save it to disk,
-# then perform random read tests of different lengths on the file
+# Parallel small file tests =====================================================================================
+for (i in 1:4) {
+  num_writers <- 2^i
+  benchmark(sprintf("Parallel DD write, 10MB over 1000 files with %d simultaneous writers", num_writers), system.time({
+    mclapply(1:num_writers, function(id) {
+      for (j in 1:1000) {
+        file <- target(sprintf("small-parallel_%d_%d.dat", id, j))
+        command <- sprintf("dd if=/dev/zero of=%s bs=1024 count=10 conv=sync oflag=nocache", file)
+        system(command, ignore.stdout = TRUE, ignore.stderr = TRUE)
+      }
+    }, mc.preschedule = FALSE, mc.cores = num_writers)
+  }))
+}
+
+for (i in 1:4) {
+  num_readers <- 2^i
+  benchmark(sprintf("Parallel DD read, 10MB over 1000 files with %d simultaneous readers", num_readers), system.time({
+    mclapply(1:num_readers, function(id) {
+      for (j in 1:1000) {
+        file <- target(sprintf("small-parallel_%d_%d.dat", id, j))
+        command <- sprintf("dd if=%s of=/dev/null bs=1024 count=10 iflag=nocache", file)
+        system(command, ignore.stdout = TRUE, ignore.stderr = TRUE)
+      }
+    }, mc.preschedule = FALSE, mc.cores = num_readers)
+  }))
+}
+
+unlink(target("small-parallel_*.dat"))
+# ===============================================================================================================
+
+# FST tests =====================================================================================================
+Generate a random data frame (approximately 1GB of data), save it to disk,
+then perform random read tests of different lengths on the file
 size_100mb <- 100*1024*1024
 num_rows <- 0.0625 * size_100mb
 size_per_row <- size_100mb / num_rows
@@ -105,9 +165,9 @@ benchmark("FST random reads, 100MB over 10000*10KB reads", system.time({
 }))
 
 unlink(target("dataset.fst"))
+#================================================================================================================
 
-# Read CRAN logs =========
-
+# Read CRAN logs ================================================================================================
 benchmark("Read 14 days of CRAN logs with fread", system.time({
   for (file in sort(dir(target("cranlogs"), full.names = TRUE))) {
     message(basename(file))
@@ -125,5 +185,6 @@ benchmark("Sample 5000 rows from each of 14 CRAN logs with vroom", system.time({
     sample(vroom_df$country, 5000)
   }
 }))
+# ===============================================================================================================
 
 benchmark_end()

--- a/main.R
+++ b/main.R
@@ -84,7 +84,7 @@ for (i in 1:4) {
 # Parallel small file tests =====================================================================================
 for (i in 1:4) {
   num_writers <- 2^i
-  benchmark(sprintf("Parallel DD write, 10MB over 1000 files with %d simultaneous writers", num_writers), system.time({
+  benchmark(sprintf("Parallel DD write, 10MB over 1000 files * %d simultaneous writers", num_writers), system.time({
     mclapply(1:num_writers, function(id) {
       for (j in 1:1000) {
         file <- target(sprintf("small-parallel_%d_%d.dat", id, j))
@@ -97,7 +97,7 @@ for (i in 1:4) {
 
 for (i in 1:4) {
   num_readers <- 2^i
-  benchmark(sprintf("Parallel DD read, 10MB over 1000 files with %d simultaneous readers", num_readers), system.time({
+  benchmark(sprintf("Parallel DD read, 10MB over 1000 files * %d simultaneous readers", num_readers), system.time({
     mclapply(1:num_readers, function(id) {
       for (j in 1:1000) {
         file <- target(sprintf("small-parallel_%d_%d.dat", id, j))


### PR DESCRIPTION
The `dd` utility was chosen here because it is heavily optimized and does not use much CPU, especially compared to similar utilities within R such as `fread`.  I wanted to minimize CPU usage as much as possible to ensure that the number of cores available on the machine did not become a limiting factor for the tests as more parallelism is used, thus ensuring the workload is truly IO bound.

These tests show that throughput for both EFS and EBS is limited and decreases (fairly) linearly when multiple tests are run simultaneously, as one would expect.

For latency, we parallelize small file tests, which show that these operations roughly decrease linearly as more clients are added as well. This makes sense, as we expect to be throughput constrained, and we expect that latency is fairly constant. However, it appears that many simultaneous writers performs exceptionally poorly on EFS compared to read performance which is quite good and tracks with EBS performance.

EBS:
```
"task","user","system","elapsed"
"Parallel DD write, 1GB * 2 simultaneous writers",0.0149999999999999,1.148,18.112
"Parallel DD write, 1GB * 4 simultaneous writers",0.038,3.556,37.687
"Parallel DD write, 1GB * 8 simultaneous writers",0.0510000000000002,8.427,72.729
"Parallel DD write, 1GB * 16 simultaneous writers",0.172,18.286,141.196
"Parallel DD read, 1GB * 2 simultaneous readers",0.0159999999999998,0.613000000000002,16.58
"Parallel DD read, 1GB * 4 simultaneous readers",0.00900000000000001,2.118,32.735
"Parallel DD read, 1GB * 8 simultaneous readers",0.0589999999999998,5.814,67.055
"Parallel DD read, 1GB * 16 simultaneous readers",0.175,13.11,134.167
"Parallel DD write, 10MB over 1000 files with 2 simultaneous writers",1.361,0.274000000000001,1.93300000000011
"Parallel DD write, 10MB over 1000 files with 4 simultaneous writers",2.739,0.479000000000009,3.39400000000001
"Parallel DD write, 10MB over 1000 files with 8 simultaneous writers",9.535,1.707,6.55999999999995
"Parallel DD write, 10MB over 1000 files with 16 simultaneous writers",20.676,3.53700000000001,13.149
"Parallel DD read, 10MB over 1000 files with 2 simultaneous readers",1.369,0.219999999999994,2.10599999999999
"Parallel DD read, 10MB over 1000 files with 4 simultaneous readers",4.04,0.629,3.28599999999994
"Parallel DD read, 10MB over 1000 files with 8 simultaneous readers",9.361,1.531,6.33000000000004
"Parallel DD read, 10MB over 1000 files with 16 simultaneous readers",18.772,3.208,12.701
```

EFS:
```
"task","user","system","elapsed"
"Parallel DD write, 1GB * 2 simultaneous writers",0.011,0.848,19.294
"Parallel DD write, 1GB * 4 simultaneous writers",0.016,2.455,40.115
"Parallel DD write, 1GB * 8 simultaneous writers",1.396,4.563,79.821
"Parallel DD write, 1GB * 16 simultaneous writers",2.674,12.029,232.121
"Parallel DD read, 1GB * 2 simultaneous readers",0.0150000000000003,0.559,17.631
"Parallel DD read, 1GB * 4 simultaneous readers",0.0240000000000005,1.864,35.059
"Parallel DD read, 1GB * 8 simultaneous readers",0.046,4.907,75.559
"Parallel DD read, 1GB * 16 simultaneous readers",0.132,10.195,244.062
"Parallel DD write, 10MB over 1000 files with 2 simultaneous writers",1.468,0.268999999999998,12.998
"Parallel DD write, 10MB over 1000 files with 4 simultaneous writers",4.509,0.826000000000003,35.562
"Parallel DD write, 10MB over 1000 files with 8 simultaneous writers",10.687,2.127,71.933
"Parallel DD write, 10MB over 1000 files with 16 simultaneous writers",23.336,4.519,146.495
"Parallel DD read, 10MB over 1000 files with 2 simultaneous readers",1.42,0.232999999999999,5.94200000000001
"Parallel DD read, 10MB over 1000 files with 4 simultaneous readers",4.225,0.763000000000003,6.26299999999992
"Parallel DD read, 10MB over 1000 files with 8 simultaneous readers",10.05,1.803,8.63599999999997
"Parallel DD read, 10MB over 1000 files with 16 simultaneous readers",21.299,4.072,15.1589999999999
```