### PR TITLE
Add the ability to run a short filesystem test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ setup:
 	make -C tools
 	sudo make -C tools install
 	Rscript setup.R
+
+short:
+	Rscript main.R short

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Two environment variables can be used to configure fsbench:
 
 * `OUTPUT_FILE` defaults to `./results-<date>-<time>.csv` and indicates the path where the benchmark results should be recorded, as CSV data. (The same results are always printed to the screen, in tabular form.)
 
+### Shortened Run
+
+```shell
+make short
+```
+This command runs the load test in a shortened form to allow for the quick assessment of a filesystem. It's not as comprehensive and doesn't load down the storage as heavily as the full run.
+
+
 ## Comparing results
 
 Once you have one or more results files from running the benchmarks, you can use the comparison tool to compare multiple runs across several filesystems. The comparison tool will average multiple runs for each distinct filesystem tested, and produce bar charts to compare performance between the different filesystems.

--- a/main.R
+++ b/main.R
@@ -6,10 +6,14 @@ library(vroom)
 
 source("_functions.R")
 short <- FALSE
+short_test == "long"
 args <- commandArgs(trailingOnly = TRUE)
-short_test <- args[1]
 
-if short_test == "short" {
+if (length(args) >= 1) {
+  short_test <- args[1]
+}
+
+if (short_test == "short") {
 short <- TRUE
 }
 

--- a/main.R
+++ b/main.R
@@ -6,7 +6,7 @@ library(vroom)
 
 source("_functions.R")
 short <- FALSE
-short_test == "long"
+short_test <- "long"
 args <- commandArgs(trailingOnly = TRUE)
 
 if (length(args) >= 1) {
@@ -16,8 +16,6 @@ if (length(args) >= 1) {
 if (short_test == "short") {
 short <- TRUE
 }
-
-print(param)
 
 benchmark_begin()
 

--- a/main.R
+++ b/main.R
@@ -28,7 +28,11 @@ benchmark("Install lattice", time_install("lattice", lib = target("lib")))
 benchmark("Install BH", time_install("BH", lib = target("lib")))
 }
 
-utils::remove.packages(c("MASS", "lattice", "BH"), lib = target("lib"))
+utils::remove.packages(c("MASS"), lib = target("lib"))
+
+if (!short){
+utils::remove.packages(c("lattice", "BH"), lib = target("lib"))
+}
 unlink(target("lib"), recursive = TRUE)
 # ===============================================================================================================
 

--- a/main.R
+++ b/main.R
@@ -9,7 +9,7 @@ short <- FALSE
 args <- commandArgs(trailingOnly = TRUE)
 
 if (length(args) >= 1) {
-  if (args[1] == "short" {
+  if (args[1] == "short") {
   short <- TRUE
   }
 }

--- a/main.R
+++ b/main.R
@@ -6,15 +6,12 @@ library(vroom)
 
 source("_functions.R")
 short <- FALSE
-short_test <- "long"
 args <- commandArgs(trailingOnly = TRUE)
 
 if (length(args) >= 1) {
-  short_test <- args[1]
-}
-
-if (short_test == "short") {
-short <- TRUE
+  if (args[1] == "short" {
+  short <- TRUE
+  }
 }
 
 benchmark_begin()


### PR DESCRIPTION
Add a shortened version of the test that runs for about 5 minutes against local storage, rather than the 15 it takes to run the full test against the local EBS drive.